### PR TITLE
change site.mk for release 2016.1

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -8,7 +8,7 @@ this_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-14 \
 	gluon-alfred \
-	gluon-announced \
+	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-autoupdater \
 	gluon-config-mode-contact-info \


### PR DESCRIPTION
siehe http://gluon.readthedocs.org/en/latest/releases/v2016.1.html

> The packages gluon-announce and gluon-announced were merged into the package gluon-respondd. If you had any of them (probably gluon-announced) in your package list, you have to replace them

and http://gluon.readthedocs.org/en/latest/user/site.html#packages
